### PR TITLE
fixed typo on code

### DIFF
--- a/otr.py
+++ b/otr.py
@@ -417,7 +417,7 @@ def command_callback(word, word_eol, userdata):
 	cmd = len(word)>1 and word[1] or ''
 	
 	
-	if   cmd=='go' or cmd=='start' or cmd='init':
+	if   cmd=='go' or cmd=='start' or cmd=='init':
 		
 		say(context.peer,context.sendMessage(0,'?OTR?')) # this will actually send the correct version-query
 		info('Query Sent...')


### PR DESCRIPTION
Line 420 says cmd='init' rather than cmd=='init' which produces a syntax error
